### PR TITLE
Remove Reddit references and add Community page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,6 +13,7 @@
           <li><a href="{{ '/tools.html' | relative_url }}"><i class="fas fa-tools"></i> Tools</a></li>
           <li><a href="{{ '/docs/labs-and-tutorials' | relative_url }}"><i class="fas fa-flask"></i> Labs</a></li>
           <li><a href="{{ '/blog/' | relative_url }}"><i class="fas fa-blog"></i> Blog</a></li>
+          <li><a href="{{ '/community/' | relative_url }}"><i class="fas fa-users"></i> Community</a></li>
           <li>
             <a href="{{ '/docs/ask-gordon' | relative_url }}">
               <i class="fas fa-robot"></i> Ask Gordon

--- a/pages/community.md
+++ b/pages/community.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: MCP Community Resources
+permalink: /community/
+---
+
+# MCP Community Resources
+
+Welcome to the Model Context Protocol (MCP) community hub. This page serves as a central resource for connecting with other MCP developers and users, accessing learning resources, and staying updated on the latest developments.
+
+## Community Channels
+
+### Discord Communities
+
+- **Docker Community Discord**: Join the official Docker Discord server where MCP developers and users gather to discuss implementation details, share best practices, and troubleshoot issues.
+
+- **Anthropic Developer Community**: Connect with Anthropic engineers and other developers building with the Model Context Protocol.
+
+### GitHub Discussions
+
+Participate in technical discussions, share your projects, and get help on the GitHub repositories:
+
+- [Anthropic MCP Cookbook](https://github.com/anthropics/anthropic-cookbook/discussions) - Official examples and tutorials
+- [MCP Portal Repository](https://github.com/ajeetraina/mcp-portal/discussions) - This website's repository for feature requests and feedback
+
+## Events and Meetups
+
+### Upcoming Events
+
+- **MCP Developers Meetup** - Monthly virtual meetups for MCP developers to share projects and learn from each other
+- **Docker x Anthropic Workshops** - Regular hands-on workshops focused on MCP integration with Docker
+
+### Past Events
+
+- Links to recordings of past meetups and workshops will be posted here
+
+## Learning Resources
+
+### Tutorials and Guides
+
+- [Getting Started with MCP Servers]()
+- [Building Your First MCP Server with Docker]()
+- [Advanced MCP Integration Patterns]()
+
+### Videos and Presentations
+
+- [Introduction to Model Context Protocol]()
+- [MCP Architecture Deep Dive]()
+- [Docker Ask Gordon & MCP Integration]()
+
+## Community Projects
+
+Highlighting interesting projects built by the community using MCP:
+
+- [Project Name 1]() - Brief description
+- [Project Name 2]() - Brief description
+- [Project Name 3]() - Brief description
+
+## Contributing
+
+Interested in contributing to the MCP ecosystem? Here are some ways to get involved:
+
+- Add your MCP server or tool to this portal (see [CONTRIBUTING.md](https://github.com/ajeetraina/mcp-portal/blob/main/CONTRIBUTING.md))
+- Submit bug reports or feature requests to the official repositories
+- Share your MCP projects with the community
+- Write tutorials or create videos about your experience with MCP
+
+## Stay Updated
+
+Subscribe to these channels to stay updated on MCP developments:
+
+- [Docker Blog](https://www.docker.com/blog/)
+- [Anthropic Blog](https://www.anthropic.com/blog)
+- [Claude API Newsletter](https://www.anthropic.com/earlyaccess)
+
+---
+
+Do you have a resource that should be included here? [Submit a Pull Request](https://github.com/ajeetraina/mcp-portal/blob/main/CONTRIBUTING.md) to add it!


### PR DESCRIPTION
## Changes Made

This PR removes Reddit references from the repository and replaces them with a more comprehensive Community page:

1. Removed Reddit link from the navigation header
2. Added a new Community page with various community resources
3. Updated the navigation to include the new Community page

The new Community page provides links to Discord communities, GitHub discussions, events, learning resources, and other community-focused content.

## Why

This change provides a more comprehensive community resource page that doesn't rely on third-party platforms for community engagement.